### PR TITLE
CI: Disable macos cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - if: matrix.os  == 'ubuntu-latest'
+        uses: actions/cache@v2
         name: Cache ~/.stack
         with:
           path: ~/.stack

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - if: matrix.os  == 'ubuntu-latest'
+        uses: actions/cache@v2
         name: Cache ~/.stack
         with:
           path: ~/.stack
@@ -52,10 +53,10 @@ jobs:
           ghc-version: "8.8.3"
           enable-stack: true
           stack-version: "latest"
-      - if:  matrix.os  == 'ubuntu-latest'
+      - if: matrix.os  == 'ubuntu-latest'
         name: Build binary (linux/static)
         run: stack install --local-bin-path dist  --flag git-brunch:static
-      - if:  matrix.os  == 'macos-latest'
+      - if: matrix.os  == 'macos-latest'
         name: Build binary (macos/dynamic)
         run: stack install --local-bin-path dist
       - name: Load Release URL File from release job

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# git-brunch [![Build Status](https://travis-ci.org/andys8/git-brunch.svg?branch=master)](https://travis-ci.org/andys8/git-brunch)
+# git-brunch [![Travis](https://travis-ci.org/andys8/git-brunch.svg?branch=master)](https://travis-ci.org/andys8/git-brunch) ![Actions](https://github.com/andys8/git-brunch/workflows/CI/badge.svg)
 
 A git checkout and rebase command-line tool
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Install it with e.g. `yay -S git-brunch` or `pamac install git-brunch`.
 #### Install
 
 ```sh
-stack install git-brunch # --resolver=lts-14.16
+stack install git-brunch # --resolver=lts-16.8
 ```
 
 #### Clone and install from source


### PR DESCRIPTION
For now it seems to be an option to disable macos cache completely and disable macos in CI builds (enable only in release).