### PR TITLE
Change CI to remove add-path warning (setup-haskell)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-stack-${{ hashFiles('**/stack.yaml.lock') }}-
             ${{ runner.os }}-stack-
-      - uses: actions/setup-haskell@v1.1
+      - uses: actions/setup-haskell@v1.1.3
         with:
           ghc-version: "8.8.3"
           enable-stack: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-stack-${{ hashFiles('**/stack.yaml.lock') }}-
             ${{ runner.os }}-stack-
-      - uses: actions/setup-haskell@v1.1
+      - uses: actions/setup-haskell@v1.1.3
         with:
           ghc-version: "8.8.3"
           enable-stack: true


### PR DESCRIPTION
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/