### PR TITLE
CI: Fix static binary build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,5 @@ jobs:
         run: stack test
       - name: Run with --version
         run: stack run -- --version
+      - name: Build statically linked
+        run: stack build --flag git-brunch:static

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ nix-env -i git-brunch
 `git-brunch` can installed with the Haskell build tool stack
 
 ```sh
-stack install git-brunch # --resolver=lts-17.4
+stack install git-brunch # --resolver=lts-17.11
 ```
 
 ### Install from source

--- a/git-brunch.cabal
+++ b/git-brunch.cabal
@@ -50,7 +50,7 @@ executable git-brunch
     , vector
     , vty
   if flag(static)
-    ghc-options: -static -threaded -rtsopts -with-rtsopts=-N -Wall -O2
+    ghc-options: -static -threaded -rtsopts -with-rtsopts=-N -Wall -O2 -optl-fuse-ld=bfd
     cc-options: -static
     ld-options: -static -pthread
   else

--- a/package.yaml
+++ b/package.yaml
@@ -49,6 +49,7 @@ executables:
             - -with-rtsopts=-N
             - -Wall
             - -O2
+            - -optl-fuse-ld=bfd
         else:
           ghc-options:
             - -threaded

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-17.4
+resolver: lts-17.11
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 563103
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/17/4.yaml
-    sha256: f11e2153044f5f71ea7b1c9398f4721f517c9bd37642ed769647b896564021f3
-  original: lts-17.4
+    size: 567672
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/17/11.yaml
+    sha256: 03181cdbeb671eb605bbcf6f285bea4d094b6ac7433a0e14a9f1dd54ad995938
+  original: lts-17.11


### PR DESCRIPTION
## Changes

* Fix CI
* Bump stackage resolver to 17.11

## See

* <https://github.com/haskell/haskell-language-server/issues/1723#issuecomment-818555247>
* <https://github.com/icfpcontest2020/starterkit-haskell/issues/2>